### PR TITLE
Fix unparsible metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,6 @@
         { "name": "puppetlabs/stdlib", "version_requirement": ">=4.3.2 < 5.0.0" },
         { "name": "puppetlabs/mysql", "version_requirement": ">=3.4.0 < 6.0.0" },
         { "name": "puppetlabs/postgresql", "version_requirement": ">=4.0.0 < 6.0.0" },
-        { "name": "puppetlabs/apt", "version_requirement": ">=2.0.0 < 5.0.0" },
+        { "name": "puppetlabs/apt", "version_requirement": ">=2.0.0 < 5.0.0" }
     ]
 }


### PR DESCRIPTION
2019-11-18 15:02:16,905 WARN  [qtp1900076236-1023] [puppetserver] Puppet powerdns has an invalid and unparsable metadata.json file. The parse error: unexpected token at ']
}
'